### PR TITLE
refactors to use '||' and '&&' instead of 'and' and 'or' operators

### DIFF
--- a/src/RedsysFakeGateway.php
+++ b/src/RedsysFakeGateway.php
@@ -86,7 +86,7 @@ class RedsysFakeGateway
 
         if (
             $inputParameters->cofIni === CofInitial::No
-            and $inputParameters->merchantIdentifier
+            && $inputParameters->merchantIdentifier
         ) {
             $returnParameters['Ds_Card_Number'] = '454881******0003';
             $returnParameters['Ds_Merchant_Cof_Txnid'] = '2006031152000';

--- a/src/RedsysResponse.php
+++ b/src/RedsysResponse.php
@@ -33,8 +33,8 @@ class RedsysResponse
 
         if (
             empty($data['Ds_SignatureVersion'])
-            or empty($data['Ds_MerchantParameters'])
-            or empty($data['Ds_Signature'])
+            || empty($data['Ds_MerchantParameters'])
+            || empty($data['Ds_Signature'])
         ) {
             throw new InvalidRedsysResponseException('Redsys: invalid response from bank.');
         }
@@ -78,6 +78,6 @@ class RedsysResponse
 
     public static function isAuthorisedCode(int $responseCode): bool
     {
-        return ! ($responseCode > 99 and $responseCode !== 400 && $responseCode !== 900);
+        return ! ($responseCode > 99 && $responseCode !== 400 && $responseCode !== 900);
     }
 }


### PR DESCRIPTION
This is a suggestion for code style that doesn't affect the logic of the methods.

While they're not part of PSR recommendations, others still suggest not using the `or` and `and`  boolean operators.

https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/master/doc/rules/operator/logical_operators.rst

(the rule could be added to csfixer)

They can have less intuitive behaviour. e.g.:

```php
$a = TRUE && FALSE; //false
$b = TRUE and FALSE;  //true
```

demo: https://onlinephp.io/c/b8e62