### PR TITLE
sendPostRequest should not force direct payment

### DIFF
--- a/src/RedsysRequest.php
+++ b/src/RedsysRequest.php
@@ -100,7 +100,6 @@ class RedsysRequest
     public function sendPostRequest(): RedsysResponse|PostRequestError
     {
         $client = new Client();
-        $this->parameters->directPayment = DirectPayment::True;
 
         $request = new Request(
             'POST',


### PR DESCRIPTION
Right now the sendPostRequest on RedsysRequest is forcing the directPayment property to true, that means that all payment request sent by that method are marked as "insecure payments", so no authentication is required.

This PR just remove that line so the user of the library could set the directPayment they want or don't do it to keep the default (false).